### PR TITLE
when finger is released on L/R screen edge, discard recording

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -15,5 +15,6 @@ const modelLanguageKey = "model_language";
 const classicPurple = Color.fromRGBO(169, 129, 234, 1.0);
 const basePurple = Color.fromRGBO(163, 95, 255, 1);
 const warmRed = Color.fromRGBO(241, 52, 125, 1.0);
+const warningRed = Color.fromRGBO(241, 20, 20, 1.0);
 final locationInstance = Location();
 const defaultEmoji = "🔮";

--- a/lib/state/notes_state.dart
+++ b/lib/state/notes_state.dart
@@ -145,7 +145,7 @@ class NotesModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> stopRecording(int color) async {
+  Future<void> stopRecording(int color, bool delete) async {
     Sentry.addBreadcrumb(
         Breadcrumb(message: "Stop recording", timestamp: DateTime.now()));
 
@@ -157,6 +157,12 @@ class NotesModel extends ChangeNotifier {
           level: SentryLevel.error);
       print("Attempted to stop recording on an empty note");
       _playerModel.stopRecording();
+      return;
+    }
+    if (delete) {
+      _playerModel.stopRecording();
+      Sentry.addBreadcrumb(
+          Breadcrumb(message: "Not saving note", timestamp: DateTime.now()));
       return;
     }
     note.color = color;

--- a/lib/views/notes_view.dart
+++ b/lib/views/notes_view.dart
@@ -290,7 +290,7 @@ class _NotesViewState extends State<_NotesView> {
   Future<void> _goToOutlines() async {
     final playerModel = context.read<PlayerModel>();
     if (playerModel.playerState == PlayerState.recordingContinuously) {
-      await context.read<NotesModel>().stopRecording(0);
+      await context.read<NotesModel>().stopRecording(0, false);
     }
     if (playerModel.playerState == PlayerState.playing) {
       await playerModel.stopPlaying();


### PR DESCRIPTION
https://user-images.githubusercontent.com/573204/157735873-7e4c7ba5-d009-43d1-a31b-a94b0e89ba3f.mov

In using VoiceLiner a ton recently, I keep finding myself stumbling over a word and wanting to easily start over. This PR allows a user to quickly discard the recording so they can start again.

Feel free to reject or push back if you'd prefer a different paradigm. :) 

https://github.com/maxkrieger/voiceliner/issues/71